### PR TITLE
feat: Implement link previews using link-preview-js

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
       </template>
     </section>
 
+    <script src="https://cdn.jsdelivr.net/npm/link-preview-js@3.0.4/dist/link-preview.min.js"></script>
     <script src="dataResources.js"></script>
     <script src="index.js"></script>
   </body>

--- a/index.js
+++ b/index.js
@@ -6,18 +6,26 @@ const typeFilters = document.querySelectorAll("#type-filters .btnFilter");
 let selectedDomain = null;
 let selectedType = null;
 
-function renderResources() {
+async function renderResources() {
   clearContainer(resourcesContainer);
 
   let resourcesToDisplay = dataResources.filter((resourceData) => {
-    const domainMatch = selectedDomain ? resourceData.tags.includes(selectedDomain) : true;
-    const typeMatch = selectedType ? resourceData.tags.includes(selectedType) : true;
+    const domainMatch = selectedDomain
+      ? resourceData.tags.includes(selectedDomain)
+      : true;
+    const typeMatch = selectedType
+      ? resourceData.tags.includes(selectedType)
+      : true;
     return domainMatch && typeMatch;
   });
 
-  resourcesToDisplay.forEach((resourceData) => {
-    const resourceCard = copyTemplateCard(resourceData);
-    resourcesContainer.appendChild(resourceCard);
+  const cardPromises = resourcesToDisplay.map((resourceData) =>
+    copyTemplateCard(resourceData)
+  );
+
+  const cards = await Promise.all(cardPromises);
+  cards.forEach((card) => {
+    resourcesContainer.appendChild(card);
   });
 }
 
@@ -25,8 +33,11 @@ function clearContainer(container) {
   container.innerHTML = "";
 }
 
-function copyTemplateCard(resourceData) {
-  const resourceTemplateContent = document.importNode(resourceTemplate.content, true);
+async function copyTemplateCard(resourceData) {
+  const resourceTemplateContent = document.importNode(
+    resourceTemplate.content,
+    true
+  );
   const card = resourceTemplateContent.querySelector("#resource");
 
   const title = card.querySelector("#title");
@@ -35,7 +46,23 @@ function copyTemplateCard(resourceData) {
 
   const previewImage = card.querySelector("#previewImage");
   const hostname = new URL(resourceData.link).hostname;
-  previewImage.src = `https://www.google.com/s2/favicons?domain=${hostname}&sz=128`;
+  const fallbackImage = `https://www.google.com/s2/favicons?domain=${hostname}&sz=128`;
+
+  try {
+    const corsProxy = "https://cors-anywhere.herokuapp.com/";
+    const preview = await linkPreview.getLinkPreview(
+      `${corsProxy}${resourceData.link}`
+    );
+    if (preview.images && preview.images.length > 0) {
+      previewImage.src = preview.images[0];
+    } else {
+      previewImage.src = fallbackImage;
+    }
+  } catch (error) {
+    console.error("Failed to get link preview", error);
+    previewImage.src = fallbackImage;
+  }
+
   previewImage.alt = resourceData.title;
 
   const description = card.querySelector("#description");


### PR DESCRIPTION
This change adds the functionality to display link previews for the resources.

- It uses the `link-preview-js` library, loaded from a CDN.
- A public CORS proxy is used to bypass browser cross-origin restrictions.
- The application now shows a preview image for each resource, with a fallback to the original favicon implementation if the preview is not available.